### PR TITLE
feat: Simplify Footer macro workaround

### DIFF
--- a/src/components/Footer.ts
+++ b/src/components/Footer.ts
@@ -2,48 +2,33 @@ import './Footer.xcss';
 
 import { compile } from 'stage1/macro' assert { type: 'macro' };
 import { h } from 'stage1/runtime';
-// import { interpolate } from '../macros' assert { type: 'macro' };
-import { decodeEntities, removeNbsp } from '../macros' assert { type: 'macro' };
+import { interpolate } from '../macros' assert { type: 'macro' };
 
 export type FooterComponent = HTMLElement;
 
 // const meta = compile(
 //   `
 //     <footer>
-//       © <a href=https://maxmilton.com class="normal muted" target=_blank>Max Milton</a> ・ v${process
-//         .env
-//         .APP_RELEASE!} ・ <a href=https://github.com/maxmilton/reader/issues target=_blank>report bug</a>
+//       © <a href=https://maxmilton.com class="normal muted" target=_blank>Max Milton</a> ・ v${process.env.APP_RELEASE} ・ <a href=https://github.com/maxmilton/reader/issues target=_blank>report bug</a>
 //     </footer>
 //   `,
 //   { keepSpaces: true },
 // );
-// const meta = compile(
-//   // FIXME: This is a convoluted workaround for a bug in the bun macro system,
-//   // where it crashes when doing string literal template interpolation. See:
-//   // https://github.com/oven-sh/bun/issues/3830
-//   interpolate(
-//     `
-//       <footer>
-//         © <a href=https://maxmilton.com class="normal muted" target=_blank>Max Milton</a> ・ v%%1%% ・ <a href=https://github.com/maxmilton/reader/issues target=_blank>report bug</a>
-//       </footer>
-//     `,
-//     [process.env.APP_RELEASE!],
-//   ),
-//   { keepSpaces: true },
-// );
 const meta = compile(
-  // FIXME: This is an alternative workaround for the bun macro bug. See: https://github.com/oven-sh/bun/issues/3830
-  decodeEntities(`
-    <footer>
-      &#169;&nbsp;<a href=https://maxmilton.com class="normal muted" target=_blank>Max Milton</a>&nbsp;&#12539; v${process.env.APP_RELEASE} &#12539;&nbsp;<a href=https://github.com/maxmilton/reader/issues target=_blank>report bug</a>
-    </footer>
-  `),
-  // FIXME: Passing objects is also currently broken. See: https://github.com/oven-sh/bun/issues/3832
-  // { keepSpaces: true },
+  // FIXME: This is a convoluted workaround for a bug in the bun macro system,
+  // where it crashes when doing string literal template interpolation. See:
+  // https://github.com/oven-sh/bun/issues/3830
+  interpolate(
+    `
+      <footer>
+        © <a href=https://maxmilton.com class="normal muted" target=_blank>Max Milton</a> ・ v%%1%% ・ <a href=https://github.com/maxmilton/reader/issues target=_blank>report bug</a>
+      </footer>
+    `,
+    [process.env.APP_RELEASE!],
+  ),
+  { keepSpaces: true },
 );
 
 export function Footer(): FooterComponent {
-  // FIXME: Remove the removeNbsp macro once bun issue #3832 is fixed.
-  return h<FooterComponent>(removeNbsp(meta.html));
-  // return h<FooterComponent>(meta.html);
+  return h<FooterComponent>(meta.html);
 }

--- a/src/components/Reader.ts
+++ b/src/components/Reader.ts
@@ -152,6 +152,7 @@ export function Reader(): ReaderComponent {
     }%)`;
 
     timer = (setTimeout as Window['setTimeout'])(
+      // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
       () => next(),
       rate * waitMultiplier(word, forceWait),
     );
@@ -205,7 +206,9 @@ export function Reader(): ReaderComponent {
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
   refs.slower.__click = () => updateWPM(wpm - 60);
+  // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
   refs.faster.__click = () => updateWPM(wpm + 60);
 
   chrome.storage.sync

--- a/src/macros.ts
+++ b/src/macros.ts
@@ -1,5 +1,3 @@
-/* eslint-disable unicorn/prefer-string-replace-all */
-
 // FIXME: Remove this file once no longer needed.
 
 // FIXME: This is a convoluted workaround for a bug in the bun macro system,
@@ -14,17 +12,4 @@ export function interpolate(text: string, values: string[]): string {
   });
 
   return result;
-}
-
-// FIXME: This is a convoluted workaround for a bug in the bun macro system,
-// where it crashes when doing string literal template interpolation. See:
-// https://github.com/oven-sh/bun/issues/3641
-export function decodeEntities(html: string): string {
-  return html.replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(+code));
-}
-
-// FIXME: This is yet another a convoluted workaround, this time for:
-// https://github.com/oven-sh/bun/issues/3832
-export function removeNbsp(html: string): string {
-  return html.replace(/&nbsp;/g, ' ');
 }

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -42,7 +42,7 @@ function setupDOM() {
 }
 
 function setupMocks(): void {
-  // normally this is set by Bun.build
+  // this is normally set in build.ts
   process.env.APP_RELEASE = '1.0.0';
 
   // @ts-expect-error - noop stub

--- a/test/unit/Reader.test.ts
+++ b/test/unit/Reader.test.ts
@@ -14,6 +14,7 @@ async function load(html: string) {
   global.chrome.scripting.executeScript = () => Promise.resolve([{ result: html }]);
 
   Loader.registry.delete(MODULE_PATH);
+  // eslint-disable-next-line unicorn/no-await-expression-member
   Reader = (await import('../../src/components/Reader')).Reader;
 }
 

--- a/test/unit/reader-app.test.ts
+++ b/test/unit/reader-app.test.ts
@@ -140,8 +140,7 @@ describe('error state', () => {
     expect(buttons[1].textContent).toBe('Play'); // changes according to state
     expect(buttons[1].disabled).toBe(true);
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-    // TODO: Use this once bun:test supports it.
-    // expect(consoleErrorSpy).toHaveBeenCalledWith(expect.any(TypeError));
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.any(TypeError));
     consoleErrorSpy.mockReset();
     checkConsoleCalls();
   });


### PR DESCRIPTION
- Complex workaround no longer necessary but we still need a workaround for string interpolation.
- Enable test assertion now that bun supports it.
- Ignore some unimportant lint warnings.